### PR TITLE
Update YahooWeatherProviderService.java

### DIFF
--- a/app/src/main/java/org/cyanogenmod/yahooweatherprovider/YahooWeatherProviderService.java
+++ b/app/src/main/java/org/cyanogenmod/yahooweatherprovider/YahooWeatherProviderService.java
@@ -179,7 +179,7 @@ public class YahooWeatherProviderService extends WeatherProviderService
                     location.getLongitude(), 1);
             Address address = addresses.get(0);
             Call<YQLResponse> wundergroundCall =
-                    mYahooWeatherServiceManager.query(address.getCountryName(),
+                    mYahooWeatherServiceManager.query(address.getCountryCode(),
                             address.getLocality());
             wundergroundCall.enqueue(new YahooWeatherRequestCallback(serviceRequest, this));
         } catch (IOException e) {


### PR DESCRIPTION
Yahoo returns 3 completly different locations when using in query address.getCountryName() and Bulgarian locale. The query can be tested on YQL Console "select * from geo.places where text="Варна, България""
it returns 1. Varna, Russia 2. Varna, Bulgaria and 3.Vahrn, Italy
When using address.getCountryCode() the result is (almost) correct.
I've tested it on my CM13.